### PR TITLE
Add support for SHA2.384

### DIFF
--- a/lib/fingerprint/scanner.rb
+++ b/lib/fingerprint/scanner.rb
@@ -32,6 +32,7 @@ module Fingerprint
 		'MD5' => lambda { Digest::MD5.new },
 		'SHA1' => lambda { Digest::SHA1.new },
 		'SHA2.256' => lambda { Digest::SHA2.new(256) },
+		'SHA2.384' => lambda { Digest::SHA2.new(384) },
 		'SHA2.512' => lambda { Digest::SHA2.new(512) },
 	}
 


### PR DESCRIPTION
SHA384 is the only hash size natively supported by Ruby in the SHA2 module that you were not supporting. This size is commonly used for Subresource integrity tags on the web and so would be convenient to store alongside web content that makes use of SRI.
